### PR TITLE
Changed the Recenter button to set the camera to its *actual* defaut position

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -88,10 +88,7 @@ pub fn gui_full(
             ui.checkbox(&mut crosshair.0, "Crosshair");
             if ui.add(egui::Button::new("Re-Center")).clicked() {
                 for mut transform in query.iter_mut() {
-                    transform.translation.x = 0.0;
-                    transform.translation.y = 0.0;
-                    transform.scale.x = 1.0;
-                    transform.scale.y = 1.0;
+                    *transform = Transform::from_xyz(0., 0., 100.0).looking_at(Vec3::ZERO, Vec3::Y);
                 }
             }
         });


### PR DESCRIPTION
This means that moving and rotating the camera brings it back to facing the right direction and to its default unrotated state.