### PR TITLE
Update the use of the enum to be much cleaner overall

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -10,9 +10,6 @@ use egui::{FontId, RichText};
 use btleplug::api::{Central, CentralEvent, Manager as _, Peripheral as _, ScanFilter};
 #[allow(unused_imports)]
 use btleplug::platform::{Adapter, Manager, Peripheral};
-// this is going to be where the states will be initialized and where they will control the outcome of the system
-
-const RESOLUTIONS: [&'static str; 3] = ["4k30", "1080p60", "1440p60(4:3)"];
 
 #[derive(Resource, Default, PartialEq)]
 pub enum Resolutions {
@@ -22,12 +19,12 @@ pub enum Resolutions {
     FourteenFourty,
 }
 
-impl std::fmt::Display for Resolutions {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Resolutions {
+    fn as_str(&self) -> &str {
         match self {
-            Self::Fourk => write!(f, "{}", RESOLUTIONS[0]),
-            Self::TenEighty => write!(f, "{}", RESOLUTIONS[1]),
-            Self::FourteenFourty => write!(f, "{}", RESOLUTIONS[2]),
+            Self::Fourk => "4k30",
+            Self::TenEighty => "1080p60",
+            Self::FourteenFourty => "1440p60(4:3)",
         }
     }
 }
@@ -82,7 +79,6 @@ pub fn setup_menu(
             .striped(true)
             .show(ui, |ui| {
                 // this is where the different items are defined
-                // start with a `ui.add()`
                 ui.add(egui::Label::new("Camera"));
                 egui::ComboBox::from_label(
                     "Select the camera that will be used to capture the video feed",
@@ -96,20 +92,19 @@ pub fn setup_menu(
                         ui.selectable_value(&mut selected, Some((name.to_string(), *ind)), name);
                     }
                 });
-                // end with a `ui.end_row()`
                 ui.end_row();
 
-                // this is for setting to either 4k30 or 1080p60
+                // this is for setting the resolutions
                 ui.add(egui::Label::new("Quality"));
                 egui::ComboBox::from_label(
                     "Select the Quality of the video feed, in combined Resolution and Frame Rate"
-                ).selected_text(format!("{}", *quality)).show_ui(ui, |ui| {
+                ).selected_text(quality.as_str()).show_ui(ui, |ui| {
                     ui.style_mut().wrap = Some(false);
                     ui.set_min_width(50.0);
                     // this is all settings for resolutions
-                    ui.selectable_value(&mut *quality, Resolutions::Fourk, RESOLUTIONS[0]);
-                    ui.selectable_value(&mut *quality, Resolutions::TenEighty, RESOLUTIONS[1]);
-                    ui.selectable_value(&mut *quality, Resolutions::FourteenFourty, RESOLUTIONS[2]);
+                    ui.selectable_value(&mut *quality, Resolutions::Fourk, Resolutions::Fourk.as_str());
+                    ui.selectable_value(&mut *quality, Resolutions::TenEighty, Resolutions::TenEighty.as_str());
+                    ui.selectable_value(&mut *quality, Resolutions::FourteenFourty, Resolutions::FourteenFourty.as_str());
                 });
                 ui.end_row();
 
@@ -160,7 +155,6 @@ pub fn setup_menu(
                 Resolutions::FourteenFourty => (nokhwa::utils::Resolution::new(1920, 1440), 60),
             };
             settings.arduino_connection = arduino.0;
-            // update the song things so that its confirmed a correct song
             settings.song = match song.0.as_str() {
                 "None" => None,
                 a => Some(a.to_string()),


### PR DESCRIPTION
Fixes the const array of strings from being used and just create an `as_str` impl for the enum in the first place.