### PR TITLE
Change to a regular camera

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -10,7 +10,7 @@ use image::{ImageBuffer, Rgba};
 use nokhwa::pixel_format::RgbAFormat;
 use nokhwa::query;
 use nokhwa::utils::{ApiBackend, CameraIndex, RequestedFormat};
-use nokhwa::CallbackCamera;
+use nokhwa::Camera;
 
 #[derive(Resource, Clone)]
 pub struct VideoFrame(pub Handle<Image>);
@@ -25,26 +25,27 @@ impl VideoStream {
         // lots of this is *heavily* taken from https://github.com/foxzool/bevy_nokhwa/blob/main/src/camera.rs
         let (sender, receiver) = bounded(1);
 
-        let callback_fn = move |buffer: nokhwa::Buffer| {
-            let mut buf = buffer.decode_image::<RgbAFormat>().unwrap();
-            let wh = (2160, 2160);
-            let image = Self::make_image(wh, &mut buf);
-            let _ = sender.send(image);
-        };
+        // let callback_fn = move |buffer: nokhwa::Buffer| {
+        //     let mut buf = buffer.decode_image::<RgbAFormat>().unwrap();
+        //     let wh = (2160, 2160);
+        //     let image = Self::make_image(wh, &mut buf);
+        //     let _ = sender.send(image);
+        // };
 
-        let mut threaded_camera = CallbackCamera::new(index, format, callback_fn)
-            .expect("Could not create a CallbackCamera");
+        // let mut threaded_camera = CallbackCamera::new(index, format, callback_fn)
+        //     .expect("Could not create a CallbackCamera");
+        let mut cam = Camera::new(index, format).unwrap();
 
-        threaded_camera
-            .open_stream()
-            .expect("Could not open the camera stream");
+        cam.open_stream().expect("Could not open the camera stream");
 
         std::thread::spawn(move || {
             #[allow(clippy::empty_loop)]
             loop {
-                threaded_camera
-                    .last_frame()
-                    .expect("Couldn't receive the latest frame");
+                let buffer = cam.frame().expect("Couldn't receive the camera frame");
+                let mut buf = buffer.decode_image::<RgbAFormat>().unwrap();
+                let wh = (2160, 2160);
+                let image = Self::make_image(wh, &mut buf);
+                let _ = sender.send(image);
             }
         });
 


### PR DESCRIPTION
This changes from a `CallbackCamera` defined in Nokhwa to a `Camera`.

This is due to the fact that the callback variant does nothing different in effect for us as well as solves an issue with sending controls to the camera.